### PR TITLE
General Improvements for 1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kolorz"
-version = "0.10.1"
+version = "1.0.0"
 edition = "2024"
 description = "A silly little library for printing kolored text to the terminal "
 repository = "https://github.com/dotzenith/kolorz.rs"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,10 @@
 
 ### ❖ Information
 
-kolorz is a silly little library for printing kolored text to the terminal 
+kolorz is a silly little library for printing kolored text to the terminal
+
+It supports a number of [kolorschemes](#-the-following-kolorschemes-are-available),
+and it respects [CLICOLOR and friends](https://bixense.com/clicolors/)
 
 ---
 
@@ -30,7 +33,7 @@ Add kolorz to your project's `Cargo.toml`:
 
 ```toml
 [dependencies]
-kolorz = "0.10.0"
+kolorz = "1.0.0"
 ```
 
 ---
@@ -42,7 +45,7 @@ kolorz = "0.10.0"
 use kolorz::Kolor;
 
 fn main() {
-    let mocha = Kolor::new("catppuccin mocha");
+    let mocha = Kolor::new("catppuccin mocha").expect("Invalid kolorscheme");
     println!("{}", mocha.red("This is red"));
 }
 ```
@@ -85,7 +88,7 @@ fn main() {
 use kolorz::HexKolorize;
 
 fn main() {
-    println!("{}", "This is peach".kolorize("#fab387"));
+    println!("{}", "This is peach".kolorize("#fab387").expect("Invalid hex color"));
 }
 ```
 
@@ -101,7 +104,7 @@ fn main() {
 ---
 
 ### ❖ What's New? 
-0.10.1 - Update Rust edition
+1.0.0 - New, Stable API with support for `CLICOLOR` and friends
 
 ---
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.92.0"
+components = ["rustc", "cargo", "rust-std", "clippy", "rustfmt", "rust-analyzer"]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,0 +1,79 @@
+use std::fmt;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnknownKolorSchemeError {
+    name: String,
+}
+
+impl UnknownKolorSchemeError {
+    pub fn new(name: impl Into<String>) -> Self {
+        Self { name: name.into() }
+    }
+
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl fmt::Display for UnknownKolorSchemeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown kolor scheme: '{}'", self.name)
+    }
+}
+
+impl std::error::Error for UnknownKolorSchemeError {}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidHexCodeError {
+    code: String,
+}
+
+impl InvalidHexCodeError {
+    pub fn new(code: impl Into<String>) -> Self {
+        Self { code: code.into() }
+    }
+
+    /// Returns the invalid hex code
+    pub fn code(&self) -> &str {
+        &self.code
+    }
+}
+
+impl fmt::Display for InvalidHexCodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "invalid hex color code: '{}'", self.code)
+    }
+}
+
+impl std::error::Error for InvalidHexCodeError {}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct InvalidColorNumberError {
+    number: usize,
+}
+
+impl InvalidColorNumberError {
+    pub const MAX_COLOR_NUMBER: usize = 6;
+
+    pub fn new(number: usize) -> Self {
+        Self { number }
+    }
+
+    /// Returns the invalid color number
+    pub fn number(&self) -> usize {
+        self.number
+    }
+}
+
+impl fmt::Display for InvalidColorNumberError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "invalid color number: {} (must be 0-{})",
+            self.number,
+            Self::MAX_COLOR_NUMBER
+        )
+    }
+}
+
+impl std::error::Error for InvalidColorNumberError {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,7 +33,6 @@ impl InvalidHexCodeError {
         Self { code: code.into() }
     }
 
-    /// Returns the invalid hex code
     pub fn code(&self) -> &str {
         &self.code
     }
@@ -59,7 +58,6 @@ impl InvalidColorNumberError {
         Self { number }
     }
 
-    /// Returns the invalid color number
     pub fn number(&self) -> usize {
         self.number
     }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -12,13 +12,73 @@ where
     fn kolorize(&self, color: &str) -> Result<KoloredText, InvalidHexCodeError> {
         let hex = color.replace("#", "").to_lowercase();
 
-        let hex_num = usize::from_str_radix(&hex, 16)
-            .map_err(|_| InvalidHexCodeError::new(color))?;
+        let hex_num =
+            usize::from_str_radix(&hex, 16).map_err(|_| InvalidHexCodeError::new(color))?;
         let kolor = (
             (hex_num >> 16) as u8,
             ((hex_num >> 8) & 0x00FF) as u8,
             (hex_num & 0x0000_00FF) as u8,
         );
         Ok(Kolor::kolorize(self.to_string(), kolor))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hex_with_hash() {
+        assert!("text".kolorize("#ff5500").is_ok());
+    }
+
+    #[test]
+    fn hex_without_hash() {
+        assert!("text".kolorize("ff5500").is_ok());
+    }
+
+    #[test]
+    fn hex_lowercase() {
+        assert!("text".kolorize("#aabbcc").is_ok());
+    }
+
+    #[test]
+    fn hex_uppercase() {
+        assert!("text".kolorize("#AABBCC").is_ok());
+    }
+
+    #[test]
+    fn hex_mixed_case() {
+        assert!("text".kolorize("#AaBbCc").is_ok());
+    }
+
+    #[test]
+    fn hex_invalid_characters() {
+        let err = "text".kolorize("gggggg").unwrap_err();
+        assert_eq!(err.code(), "gggggg");
+    }
+
+    #[test]
+    fn hex_invalid_with_hash() {
+        let err = "text".kolorize("#nothex").unwrap_err();
+        assert_eq!(err.code(), "#nothex");
+    }
+
+    #[test]
+    fn hex_produces_correct_rgb() {
+        let output = "x".kolorize("#ff8000").unwrap().to_string();
+        assert!(output.contains("255;128;0"));
+    }
+
+    #[test]
+    fn hex_black() {
+        let output = "x".kolorize("#000000").unwrap().to_string();
+        assert!(output.contains("0;0;0"));
+    }
+
+    #[test]
+    fn hex_white() {
+        let output = "x".kolorize("#ffffff").unwrap().to_string();
+        assert!(output.contains("255;255;255"));
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -1,19 +1,24 @@
+use crate::errors::InvalidHexCodeError;
 use crate::{Kolor, KoloredText};
 
 pub trait HexKolorize {
-    fn kolorize(&self, color: &str) -> KoloredText;
+    fn kolorize(&self, color: &str) -> Result<KoloredText, InvalidHexCodeError>;
 }
 
-impl<T> HexKolorize for T where T: std::fmt::Display + Into<String>  {
-    fn kolorize(&self, color: &str) -> KoloredText {
+impl<T> HexKolorize for T
+where
+    T: std::fmt::Display,
+{
+    fn kolorize(&self, color: &str) -> Result<KoloredText, InvalidHexCodeError> {
         let hex = color.replace("#", "").to_lowercase();
 
-        let hex_num = usize::from_str_radix(&hex, 16).unwrap();
+        let hex_num = usize::from_str_radix(&hex, 16)
+            .map_err(|_| InvalidHexCodeError::new(color))?;
         let kolor = (
             (hex_num >> 16) as u8,
             ((hex_num >> 8) & 0x00FF) as u8,
             (hex_num & 0x0000_00FF) as u8,
         );
-        Kolor::kolorize(self.to_string(), kolor)
+        Ok(Kolor::kolorize(self.to_string(), kolor))
     }
 }

--- a/src/hex.rs
+++ b/src/hex.rs
@@ -66,18 +66,21 @@ mod tests {
 
     #[test]
     fn hex_produces_correct_rgb() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "x".kolorize("#ff8000").unwrap().to_string();
         assert!(output.contains("255;128;0"));
     }
 
     #[test]
     fn hex_black() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "x".kolorize("#000000").unwrap().to_string();
         assert!(output.contains("0;0;0"));
     }
 
     #[test]
     fn hex_white() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "x".kolorize("#ffffff").unwrap().to_string();
         assert!(output.contains("255;255;255"));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,9 @@
 //! ```rust
 //! use kolorz::Kolor;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     let mocha = Kolor::new("catppuccin mocha")?;
+//! fn main() {
+//!     let mocha = Kolor::new("catppuccin mocha").expect("Invalid kolorscheme");
 //!     println!("{}", mocha.red("This is red"));
-//!     Ok(())
 //! }
 //! ```
 //!
@@ -56,9 +55,8 @@
 //! ```rust
 //! use kolorz::HexKolorize;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     println!("{}", "This is peach".kolorize("#fab387")?);
-//!     Ok(())
+//! fn main() {
+//!     println!("{}", "This is peach".kolorize("#fab387").expect("Invalid Hex"));
 //! }
 //! ```
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ fn main() {
         BiscuitLight,
     ];
 
-    for colorscheme in colorschemes.iter() {
-        let cur = Kolor::new(colorscheme);
+    for colorscheme in colorschemes.into_iter() {
+        let cur = Kolor::new(colorscheme).expect("Invalid kolorscheme");
         println!("{:?}", colorscheme);
         println!(
             "{} {} {} {} {} {} {} {}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
-use kolorz::{Kolor, KolorScheme};
 use KolorScheme::*;
+use kolorz::{Kolor, KolorScheme};
 
 fn main() {
     let colorschemes = [

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -19,30 +19,35 @@ mod tests {
 
     #[test]
     fn rgb_kolorize() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "test".kolorize((100, 150, 200)).to_string();
         assert!(output.contains("100;150;200"));
     }
 
     #[test]
     fn rgb_min_values() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "t".kolorize((0, 0, 0)).to_string();
         assert!(output.contains("0;0;0"));
     }
 
     #[test]
     fn rgb_max_values() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "t".kolorize((255, 255, 255)).to_string();
         assert!(output.contains("255;255;255"));
     }
 
     #[test]
     fn rgb_mixed_values() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "t".kolorize((255, 0, 128)).to_string();
         assert!(output.contains("255;0;128"));
     }
 
     #[test]
     fn rgb_output_format() {
+        unsafe { std::env::set_var("CLICOLOR_FORCE", "1") };
         let output = "hello".kolorize((10, 20, 30)).to_string();
         assert!(output.starts_with("\x1b[38;2;"));
         assert!(output.ends_with("\x1b[0m"));

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -4,8 +4,48 @@ pub trait RGBKolorize {
     fn kolorize(&self, color: RGB) -> KoloredText;
 }
 
-impl<T> RGBKolorize for T where T: std::fmt::Display + Into<String>  {
+impl<T> RGBKolorize for T
+where
+    T: std::fmt::Display + Into<String>,
+{
     fn kolorize(&self, color: RGB) -> KoloredText {
         Kolor::kolorize(self.to_string(), color)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rgb_kolorize() {
+        let output = "test".kolorize((100, 150, 200)).to_string();
+        assert!(output.contains("100;150;200"));
+    }
+
+    #[test]
+    fn rgb_min_values() {
+        let output = "t".kolorize((0, 0, 0)).to_string();
+        assert!(output.contains("0;0;0"));
+    }
+
+    #[test]
+    fn rgb_max_values() {
+        let output = "t".kolorize((255, 255, 255)).to_string();
+        assert!(output.contains("255;255;255"));
+    }
+
+    #[test]
+    fn rgb_mixed_values() {
+        let output = "t".kolorize((255, 0, 128)).to_string();
+        assert!(output.contains("255;0;128"));
+    }
+
+    #[test]
+    fn rgb_output_format() {
+        let output = "hello".kolorize((10, 20, 30)).to_string();
+        assert!(output.starts_with("\x1b[38;2;"));
+        assert!(output.ends_with("\x1b[0m"));
+        assert!(output.contains("hello"));
     }
 }

--- a/src/rgb.rs
+++ b/src/rgb.rs
@@ -1,11 +1,11 @@
-use crate::{Kolor, KoloredText};
+use crate::{Kolor, KoloredText, RGB};
 
 pub trait RGBKolorize {
-    fn kolorize(&self, color: (u8, u8, u8)) -> KoloredText;
+    fn kolorize(&self, color: RGB) -> KoloredText;
 }
 
 impl<T> RGBKolorize for T where T: std::fmt::Display + Into<String>  {
-    fn kolorize(&self, color: (u8, u8, u8)) -> KoloredText {
+    fn kolorize(&self, color: RGB) -> KoloredText {
         Kolor::kolorize(self.to_string(), color)
     }
 }


### PR DESCRIPTION
Parts of the library have been bothering me for a little while now. It works, but it felt klunky in certain places. This PR is an attempt to fix that.

- Fix misc annoyances:
  - Return Result instead of panicking or silently defaulting. This includes adding real Error types.
  - Remove unnecessary allocations and add bounds checking
  - Make `Kolor`, `KolorScheme` and `KoloredText` Debug

- Add support for [CLICOLOR spec](https://bixense.com/clicolors/)
- Add tests
